### PR TITLE
Examples on how to test sharedPrefefrences persistence

### DIFF
--- a/secret-diary/stage4/src/main/java/org/hyperskill/secretdiary/MainActivity.kt
+++ b/secret-diary/stage4/src/main/java/org/hyperskill/secretdiary/MainActivity.kt
@@ -59,6 +59,7 @@ class MainActivity : AppCompatActivity() {
             )
             binding.tvDiary.text = diary.toString()
             binding.etNewWriting.text.clear()
+            persistDiary()
         } else {
             Toast.makeText(this, "Empty or blank input cannot be saved", Toast.LENGTH_SHORT).show()
         }
@@ -72,6 +73,7 @@ class MainActivity : AppCompatActivity() {
                 diary.removeFirstOrNull()
                 updateTvDiary()
                 dialog.dismiss()
+                persistDiary()
             }
             .setNegativeButton("No") { dialog, which ->
                 dialog.dismiss()
@@ -84,12 +86,16 @@ class MainActivity : AppCompatActivity() {
         binding.tvDiary.text = diary.toString()
     }
 
-
-    override fun onStop() {
-        super.onStop()
+    private fun persistDiary() {
         val sp = getSharedPreferences(PREF_DIARY, Context.MODE_PRIVATE)
         val editor = sp.edit()
         editor.putString(KEY_DIARY_TEXT, diary.toString())
         editor.apply()
+    }
+
+
+    override fun onStop() {
+        persistDiary()
+        super.onStop()
     }
 }

--- a/secret-diary/stage4/src/test/java/org/hyperskill/secretdiary/Stage4UnitTest.kt
+++ b/secret-diary/stage4/src/test/java/org/hyperskill/secretdiary/Stage4UnitTest.kt
@@ -337,7 +337,7 @@ class Stage4UnitTest : AbstractUnitTest<MainActivity>(MainActivity::class.java) 
     fun testShouldCheckPersistAndRestoreWithLifecycle() {
         // I don't think this is really necessary, you can test persist and restore separately, but if you prefer this way it is possible
 
-        testActivity {
+        val returnedValue = testActivity {
             // ensure all views used on test are initialized with initial state
             etNewWriting
             btnSave
@@ -381,10 +381,13 @@ class Stage4UnitTest : AbstractUnitTest<MainActivity>(MainActivity::class.java) 
 
             val actualPersistedValue = sharedPreferences.getString(KEY_DIARY_TEXT, "null")
             assertEquals("some error message", diaryText2, actualPersistedValue)
+
+            //return the value
+            actualPersistedValue
         }
 
-        val bundle: Bundle = Bundle()
-        activityController.saveInstanceState(bundle)
+
+        activityController
             .pause()
             .stop()
             .destroy()
@@ -396,9 +399,10 @@ class Stage4UnitTest : AbstractUnitTest<MainActivity>(MainActivity::class.java) 
         val sharedPreferences = recreateActivityUnitTest.activity.application.getSharedPreferences(
             PREF_DIARY, MODE_PRIVATE
         )
+        sharedPreferences.edit().putString(KEY_DIARY_TEXT, returnedValue).commit()
 
         //do the testing
-        recreateActivityUnitTest.testActivity(savedInstanceState = bundle) {
+        recreateActivityUnitTest.testActivity(/*savedInstanceState = bundle*/) {
 
             // I have changed the member of AbstractUnitTest to public so it is possible to have access to its members
             // I did this change some days ago on the template too, so you can make everything public on AbstractUnitClass for all stages to follow along (files with same name should have same content across stages)

--- a/secret-diary/stage4/src/test/java/org/hyperskill/secretdiary/internals/AbstractUnitTest.kt
+++ b/secret-diary/stage4/src/test/java/org/hyperskill/secretdiary/internals/AbstractUnitTest.kt
@@ -2,6 +2,7 @@ package org.hyperskill.secretdiary.internals
 
 import android.app.Activity
 import android.content.Intent
+import android.os.Bundle
 import android.view.View
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -18,7 +19,7 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
     /**
      * Setup and control activities and their lifecycle
      */
-    protected var activityController: ActivityController<T> by lazy {
+    val activityController: ActivityController<T> by lazy {
         Robolectric.buildActivity(clazz)
     }
 
@@ -27,7 +28,7 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
      *
      * It is the @RealObject of the shadowActivity
      */
-    protected val activity : Activity by lazy {
+    val activity : Activity by lazy {
         activityController.get()
     }
 
@@ -39,7 +40,7 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
      * If you don't know what shadows are you can have a better understanding on that reading this
      * on roboletric documentation: http://robolectric.org/extending/
      */
-    protected val shadowActivity: ShadowActivity by lazy {
+    val shadowActivity: ShadowActivity by lazy {
         Shadow.extract(activity)
     }
 
@@ -48,7 +49,7 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
      *
      * Usually used with .idleFor(someDurationValue) or .runToEndOfTasks()
      */
-    protected val shadowLooper: ShadowLooper by lazy {
+    val shadowLooper: ShadowLooper by lazy {
         shadowOf(activity.mainLooper)
     }
 
@@ -58,10 +59,10 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
      *
      * returns a value for convenience use, like in tests that involve navigation between Activities
      */
-    fun <ReturnValue> testActivity(arguments: Intent = Intent(), testCodeBlock: (Activity) -> ReturnValue): ReturnValue {
+    fun <ReturnValue> testActivity(arguments: Intent = Intent(), savedInstanceState: Bundle = Bundle(), testCodeBlock: (Activity) -> ReturnValue): ReturnValue {
         try {
             activity.intent =  arguments
-            activityController.setup()
+            activityController.setup(savedInstanceState)
         } catch (ex: Exception) {
             throw AssertionError("Exception, test failed on activity creation with $ex\n${ex.stackTraceToString()}")
         }
@@ -118,7 +119,7 @@ abstract class AbstractUnitTest<T : Activity>(clazz: Class<T>) {
      *
      * Internally it calls performClick() and shadowLooper.idleFor(millis)
      */
-    protected fun View.clickAndRun(millis: Long = 500){
+    fun View.clickAndRun(millis: Long = 500){
         this.performClick()
         shadowLooper.idleFor(Duration.ofMillis(millis))
     }


### PR DESCRIPTION
First thing i changed solution a bit because I don't think it is reliable to be counting on OnStop() to be called to actually persist data, your app might never have the chance to call it if it crashes or if it is force-closed. It is not an expensive call you can do it every time the state to be persisted changes (btnSave click, btnUndo click, etc..).
(ps: I left the OnStop there, but it is not necessary in my opinion. Also my test examples is not assuming it is called.)

I did some examples of how to do the test, I prefer to make separate tests for persisting and for restoring because it is just easier. 

I did one with both together, the trick is to make an anonymous object that extends AbstractUnitTest and do the remaining tests over it, but it is trickier, you have to be careful to not use things from the old activity, including the fields instantiated in StageUnitTest.